### PR TITLE
add autoloadsave = False keyword when initialing

### DIFF
--- a/LOSSPhotPypeline/pipeline/LPP.py
+++ b/LOSSPhotPypeline/pipeline/LPP.py
@@ -39,7 +39,7 @@ class LPP(object):
     '''Lick Observatory Supernova Search Photometry Reduction Pipeline'''
 
     def __init__(self, targetname, interactive = True, parallel = True, cal_diff_tol = 0.05, force_color_term = False,
-                 wdir = '.', override_ref_check = True, sep_tol = 8):
+                 wdir = '.', override_ref_check = True, sep_tol = 8, autoloadsave = False):
         '''Instantiation instructions'''
 
         # basics from instantiation
@@ -169,6 +169,8 @@ class LPP(object):
                 load = input('Load saved state from {}? ([y]/n) > '.format(self.savefile))
             else:
                 load = 'n' # run fresh if in non-interactive mode
+                if autoloadsave :
+                    load = 'y' # run fresh if in non-interactive mode, unless this keyword is set
             if 'n' not in load.lower():
                 self.load()
 


### PR DESCRIPTION
Only add these two lines, plus a key word in initial function
                if autoloadsave :
                    load = 'y' # run fresh if in non-interactive mode, unless this keyword is set.

I'd like to use this option when load from save in non-interactive mode. This is to avoid download the catalog again, which sometimes takes a long time and may hang there too. 