### PR TITLE
if override_ref_check faild, select 90% common refstars

### DIFF
--- a/LOSSPhotPypeline/pipeline/LPP.py
+++ b/LOSSPhotPypeline/pipeline/LPP.py
@@ -517,8 +517,8 @@ class LPP(object):
         coords = SkyCoord(imagera, imagedec, unit = (u.deg, u.deg))
         target_coords = SkyCoord(self.targetra, self.targetdec, unit = (u.deg, u.deg))
         offsets = coords.separation(target_coords).arcsecond
-        imagera = imagera[offsets < self.sep_tol]
-        imagedec = imagedec[offsets < self.sep_tol]
+        imagera = imagera[offsets > self.sep_tol]
+        imagedec = imagedec[offsets > self.sep_tol]
 
         # write radec file
         with open(self.radecfile, 'w') as f:


### PR DESCRIPTION
Still some fraction of fields failed, though a small portion, <15% percent. But since I need to process a large number of fields, >2000, so still hundreds of the fields failed, I hope it can still run through photometry even override_ref_check faild.
I brought back earlier changes I tried to make, but this time, only run that if override_ref_check failed, and I select the 90% common refer stars as the first step during calibration. I was trying to select the 5 most common stars, but didn't find a easy way to do so to replace this line:

cut_list.extend(list(df.index[df.loc[:, 'pct_im'] < 0.90]))

For now, it's 90% common cut.